### PR TITLE
Switch to Geist font

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,5 +1,4 @@
 // next
-import { Inter } from "next/font/google";
 // anayltics
 import GoogleAnalytics from "@bradgarropy/next-google-analytics/";
 import { Analytics } from "@vercel/analytics/react";
@@ -11,7 +10,6 @@ import "../styles/globals.css";
 import Header from "@/components/Header";
 import CustomCursor from "@/components/CustomCursor";
 
-const inter = Inter({ subsets: ["latin"] });
 
 export const metadata = {
   title: "Ulaş Alyeşil | Product Designer",
@@ -21,7 +19,7 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body className={inter.className}>
+      <body>
         <CustomCursor />
         <div className="flex flex-col sm:p-6 p-4 items-center pt-12 sm:pt-32">
           <Header />

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.2.0",
       "dependencies": {
         "@bradgarropy/next-google-analytics": "^1.0.2",
+        "@fontsource-variable/geist": "^5.2.6",
+        "@fontsource-variable/geist-mono": "^5.2.6",
         "@radix-ui/react-icons": "^1.3.2",
         "@vercel/analytics": "^1.0.1",
         "framer-motion": "^12.23.6",
@@ -251,6 +253,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fontsource-variable/geist": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/geist/-/geist-5.2.6.tgz",
+      "integrity": "sha512-Bt9pdD55Fojq4h9yFKQAzh5+Xj4tKFpwbcDzK6t5PPSH2GrjPoPqm6N8y+tK6vzwKZ9hHyaOz/tAbO9cQd9UFQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/geist-mono": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/geist-mono/-/geist-mono-5.2.6.tgz",
+      "integrity": "sha512-vw6T9JGTrYJ980bn7W8iTPhe2jVK5ifunVs7xh9dfTVArjDSkJs03JjeZrH5LKEpGABLXSlSlNU57HRm4tmFMg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@formatjs/ecma402-abstract": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "@bradgarropy/next-google-analytics": "^1.0.2",
+    "@fontsource-variable/geist": "^5.2.6",
+    "@fontsource-variable/geist-mono": "^5.2.6",
     "@radix-ui/react-icons": "^1.3.2",
     "@vercel/analytics": "^1.0.1",
     "framer-motion": "^12.23.6",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,11 +1,18 @@
 @import 'tailwindcss';
+@import '@fontsource-variable/geist/index.css';
+@import '@fontsource-variable/geist-mono/index.css';
 
 html {
-  font-family: "Inter", sans-serif;
+  font-family: "Geist Variable", sans-serif;
   font-size: 16px;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+code,
+pre {
+  font-family: "Geist Mono Variable", monospace;
 }
 
 body {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,10 +1,19 @@
 /** @type {import('tailwindcss').Config} */
+const defaultTheme = require('tailwindcss/defaultTheme');
+
 module.exports = {
   content: [
     './app/**/*.{js,ts,jsx,tsx,mdx}',
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',
   ],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['"Geist Variable"', ...defaultTheme.fontFamily.sans],
+        mono: ['"Geist Mono Variable"', ...defaultTheme.fontFamily.mono],
+      },
+    },
+  },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- swap local Inter font for Geist variable fonts (sans and mono)
- import Geist fonts in global CSS
- customize Tailwind config so font utilities use Geist

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a478d1fc48327be740edef572a5fd