### PR TITLE
Revert last typo fix

### DIFF
--- a/app/not-found.jsx
+++ b/app/not-found.jsx
@@ -5,7 +5,7 @@ import ContactCard from '@/components/ContactCard';
 export default function NotFound() {
   return (
     <div className="text-neutral-900 dark:text-neutral-100 flex flex-col m-auto p-auto justify-center items-center h-screen gap-4">
-      <h1 className="text-2xl font-bold max-w-[556px] text-center">We regret to inform that we decided to move on with other pages. We&apos;ll keep your candidate info and reach out if we see any fit.</h1>
+      <h1 className="text-2xl font-bold max-w-[556px] text-center">We regret to inform that we decided to move on with other pages. We'll keep your candidate info and reach out if we see any fit.</h1>
       <div className='flex gap-4 items-center'>
         <p>Go</p>
           <Button href={'/'} label={"Home"} type={"primary"} />


### PR DESCRIPTION
## Summary
- revert change from 404 page typo fix

## Testing
- `npm run lint` *(fails: `'` can be escaped with `&apos;`, `&lsquo;`, `&#39;`, `&rsquo;`)*

------
https://chatgpt.com/codex/tasks/task_e_687a7cb3869c8327a51b34800b0f3b4a